### PR TITLE
Problem solved by excluding spring boot's internal hibernate-entitymanager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,4 @@ Example: ghostzali(Akhmad Ghozali Amrulloh) ghostzali2011@gmail.com
 # Contributor List
 
 - ghostzali(Akhmad Ghozali Amrulloh) ghostzali2011@gmail.com
+- lex91(Alexander Schnebel) ax.schnebel@gmail.com

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ repositories {
 }
 
 dependencies {
-	compile('org.springframework.boot:spring-boot-starter-data-jpa')
+	compile('org.springframework.boot:spring-boot-starter-data-jpa') {
+		exclude module: 'hibernate-entitymanager'
+	}
 	compile('org.springframework.boot:spring-boot-starter-jdbc')
 	compile('org.springframework.boot:spring-boot-starter-jersey')
 	compile('org.springframework.boot:spring-boot-starter-validation')

--- a/src/main/java/id/goindonesia/area/indonesia/AreaIndonesiaApplication.java
+++ b/src/main/java/id/goindonesia/area/indonesia/AreaIndonesiaApplication.java
@@ -5,10 +5,14 @@ import id.goindonesia.area.indonesia.setup.DataImport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@EnableAutoConfiguration
+@ComponentScan
 public class AreaIndonesiaApplication {
 
     @Autowired

--- a/src/test/java/id/goindonesia/area/indonesia/AreaIndonesiaApplicationTests.java
+++ b/src/test/java/id/goindonesia/area/indonesia/AreaIndonesiaApplicationTests.java
@@ -2,6 +2,7 @@ package id.goindonesia.area.indonesia;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 


### PR DESCRIPTION
Spring Boot 1.5.3 provides Hibernate by default. But it also supports only hibernate-core until version 5.0.12-Final (see: https://docs.spring.io/spring-boot/docs/1.5.3.RELEASE/reference/html/appendix-dependency-versions.html). Since you using a newer version you have to exclude the 'hibernate-entitymanager' from 'org.springframework.boot:spring-boot-starter-data-jpa'.

I used gradle 4.2.1 and java version "1.8.0_141" and Gradle 4.2.1